### PR TITLE
Update Japanese translations for "Getting Started" and "Modules"

### DIFF
--- a/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/_category_.json
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/_category_.json
@@ -1,10 +1,10 @@
 {
-  "label": "Getting Started",
+  "label": "最初のステップ",
   "collapsible": true,
   "collapsed": false,
   "position": 2,
   "link": {
     "type": "generated-index",
-    "description": "Get Started"
+    "description": "始まり"
   }
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/modules/_category_.json
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/modules/_category_.json
@@ -1,8 +1,8 @@
 {
-  "label": "Modules",
+  "label": "モジュール",
   "position": 3,
   "link": {
     "type": "generated-index",
-    "description": "Modules"
+    "description": "モジュール"
   }
 }


### PR DESCRIPTION
Improve the Japanese localization by updating the translations for the "Getting Started" and "Modules" sections.